### PR TITLE
Add city geocoding with OpenWeather API and update main bot text handler

### DIFF
--- a/geocode.js
+++ b/geocode.js
@@ -1,0 +1,47 @@
+// geocode.js
+require('dotenv').config();
+const axios = require('axios');
+
+const API_KEY = process.env.OPENWEATHER_API_KEY;
+if (!API_KEY) {
+  console.error('ERROR: OPENWEATHER_API_KEY is not set in .env');
+  // We don't exit so other code can still be required in tests, but calls will fail gracefully.
+}
+
+/**
+ * geocodeCity
+ * Input: city (string), optional limit (number)
+ * Output: array of { name, lat, lon, country, state }
+ */
+async function geocodeCity(city, limit = 5) {
+  if (!city || typeof city !== 'string') {
+    throw new Error('geocodeCity: city is required and must be a string');
+  }
+
+  const q = encodeURIComponent(city.trim());
+  const url = `https://api.openweathermap.org/geo/1.0/direct?q=${q}&limit=${limit}&appid=${API_KEY}`;
+
+  try {
+    const res = await axios.get(url);
+    const data = res.data;
+
+    if (!Array.isArray(data) || data.length === 0) {
+      return [];
+    }
+
+    // Normalize results to a simple shape
+    return data.map((item) => ({
+      name: item.name,
+      lat: item.lat,
+      lon: item.lon,
+      country: item.country,
+      state: item.state || null,
+    }));
+  } catch (err) {
+    // Log useful debug info (don't log raw API key)
+    console.error('geocodeCity error:', err.response ? err.response.data : err.message);
+    return [];
+  }
+}
+
+module.exports = { geocodeCity };

--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ const { Telegraf, Markup } = require("telegraf"); // We now need 'Markup'
 //import our custom function from api.js
 const { getPrayerTimes } = require("./api.js");
 
+// Import the geocodeCity function
+const { geocodeCity } = require("./geocode.js");
+
+
 if (!process.env.BOT_TOKEN) {
   console.error("ERROR: BOT_TOKEN is not set in the .env file!");
   process.exit(1);
@@ -63,11 +67,54 @@ bot.on('location', async(ctx)=>{
 
 //--Handler for non location sharing devices like desktop, which is by text based. they type the city
 
-bot.on('text', async (ctx)=>{
-    const messageText = ctx.message.text;
-    {
-        //hear is your work place
+bot.on('text', async (ctx) => {
+    const cityName = ctx.message.text.trim();
+
+    // Get possible matches from OpenWeather's Geocoding API
+    const matches = await geocodeCity(cityName);
+
+    if (matches.length === 0) {
+        return ctx.reply(`❌ Sorry, I couldn't find "${cityName}". Please check the spelling and try again.`);
     }
+
+    if (matches.length === 1) {
+        // Only one match found — fetch prayer times directly
+        const { lat, lon, name, country } = matches[0];
+        await ctx.reply(`📍 Found: ${name}, ${country}`);
+        return sendPrayerTimes(ctx, lat, lon);
+    }
+
+    // More than one match — list them for the user
+    let replyText = `I found multiple matches for "${cityName}":\n`;
+    matches.forEach((place, i) => {
+        replyText += `${i + 1}. ${place.name}, ${place.state ? place.state + ', ' : ''}${place.country}\n`;
+    });
+    replyText += `\nPlease reply with the number of your city.`;
+
+    // Store matches temporarily for this user
+    if (!global.cityChoices) global.cityChoices = new Map();
+    global.cityChoices.set(ctx.from.id, matches);
+
+    await ctx.reply(replyText);
+});
+
+// Optional handler to catch numeric replies for city choice
+bot.on('text', async (ctx) => {
+    const choice = parseInt(ctx.message.text.trim(), 10);
+    if (!global.cityChoices || !global.cityChoices.has(ctx.from.id)) return;
+
+    const matches = global.cityChoices.get(ctx.from.id);
+    if (isNaN(choice) || choice < 1 || choice > matches.length) {
+        return ctx.reply(`❌ Invalid choice. Please reply with a number between 1 and ${matches.length}.`);
+    }
+
+    const { lat, lon, name, country } = matches[choice - 1];
+    await ctx.reply(`📍 Selected: ${name}, ${country}`);
+
+    // Remove stored choices after selection
+    global.cityChoices.delete(ctx.from.id);
+
+    return sendPrayerTimes(ctx, lat, lon);
 });
 
 bot.launch();

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 // At the top with the other require statements
 require("dotenv").config();
 const { Telegraf, Markup } = require("telegraf"); // We now need 'Markup'
@@ -49,7 +48,7 @@ async function sendPrayerTimes(ctx, latitude, longitude){
 
           await ctx.reply(responseMessage);
     }else{
-        await ctx.reply('Sorry, Icoudn\'t fetch the prayer times for teh location. Please try again.');
+        await ctx.reply('Sorry, I couldn\'t fetch the prayer times for the location. Please try again.');
     }
 }
 
@@ -62,7 +61,7 @@ bot.on('location', async(ctx)=>{
     await sendPrayerTimes(ctx, latitude,longitude);
 });
 
-//--Handler for non location sharing devices like desktop, which is by text based. they tyoe the city
+//--Handler for non location sharing devices like desktop, which is by text based. they type the city
 
 bot.on('text', async (ctx)=>{
     const messageText = ctx.message.text;
@@ -72,7 +71,7 @@ bot.on('text', async (ctx)=>{
 });
 
 bot.launch();
-console.log('Bot is running....');
+console.log('Bot is running...');
 
 process.once('SIGINT', ()=> bot.stop('SIGINT'));
 process.once('SIGTERM', ()=> bot.stop('SIGTERM'));


### PR DESCRIPTION
This PR adds a new feature allowing desktop users to type a city name to get prayer times.

- Created the geocodeCity function in geocode.js that fetches city coordinates using OpenWeather’s Geocoding API.

Updated main bot file to handle text input:

1. Converts city name to coordinates using geocodeCity.
2. Handles zero, single, or multiple city matches and prompts the user accordingly.
3. Sends prayer times based on selected coordinates.

Error handling and user prompts improve the UX for desktop users without location sharing.
Please review and merge if all looks good!